### PR TITLE
STUD-28: HTML decoded the result from translation

### DIFF
--- a/ting_subsearch_translate.module
+++ b/ting_subsearch_translate.module
@@ -101,14 +101,15 @@ function ting_subsearch_translate_suggest_translated_keys($keys) {
       )
     );
     $result = json_decode($response->getBody());
+
+    if (!empty($result->data->translations[0]->translatedText)) {
+      $translation = (string) $result->data->translations[0]->translatedText;
+      return html_entity_decode($translation, ENT_QUOTES);
+    }
   }
   catch (GuzzleClientException $e) {
     watchdog_exception('ting_subsearch_translate', $e);
     return FALSE;
-  }
-
-  if (!empty($result->data->translations[0]->translatedText)) {
-    return (string) $result->data->translations[0]->translatedText;
   }
 
   return FALSE;


### PR DESCRIPTION
It turned out that "kvindekamp" returns "women&#39;s liberation" this PR decoded that to "women's liberation".

Fun note: google translation of "kvindekamp" and "Kvindekamp" is not the same :-)